### PR TITLE
Fix wrong line breaks in Beagle script

### DIFF
--- a/Modules/09_imputation/beagle_impute.slurm
+++ b/Modules/09_imputation/beagle_impute.slurm
@@ -7,7 +7,7 @@
 #SBATCH --mem=128G
 #SBATCH --time=99:00:00
 
-java -jar beagle.01Mar24.d36.jar /
-ref=AutoAndXPAR.Dog10K.phased.vcf.gz/
-gt=joint_calls.snps.recalibrated.vcf.gz /
-out=canfam4_lpwgs.vcf
+java -jar beagle.01Mar24.d36.jar \
+    ref=AutoAndXPAR.Dog10K.phased.vcf.gz \
+    gt=joint_calls.snps.recalibrated.vcf.gz \
+    out=canfam4_lpwgs.vcf


### PR DESCRIPTION
## Summary
- correct the line continuations in `beagle_impute.slurm`

## Testing
- `shellcheck Modules/09_imputation/beagle_impute.slurm`

------
https://chatgpt.com/codex/tasks/task_e_6842d0deabc083339bf738bc4381ca99