### PR TITLE
Add Bats test for extract_relevant_stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,13 @@ This repository offers a modular, SLURM-compatible pipeline for low-pass sequenc
 
 7. Genotype Imputation (modules/09_imputation)
    - beagle_impute.sh: Run BEAGLE with reference panel, genetic maps, and compute dosage R².
+
+## Running the tests
+
+The optional tests use [bats](https://github.com/bats-core/bats-core). After installing `bats` (for example with `apt-get install bats`), run:
+
+```bash
+bats tests
+```
+
+This executes the test suite under the `tests/` directory.

--- a/tests/data/example.flagstat.txt
+++ b/tests/data/example.flagstat.txt
@@ -1,0 +1,13 @@
+4 + 0 in total (QC-passed reads + QC-failed reads)
+0 + 0 secondary
+0 + 0 supplementary
+0 + 0 duplicates
+4 + 0 mapped (100.00% : N/A)
+4 + 0 paired in sequencing
+2 + 0 read1
+2 + 0 read2
+4 + 0 properly paired (100.00% : N/A)
+0 + 0 with itself and mate mapped
+0 + 0 singletons (0.00% : N/A)
+0 + 0 with mate mapped to a different chr
+0 + 0 with mate mapped to a different chr (mapQ>=5)

--- a/tests/test_extract_relevant_stats.bats
+++ b/tests/test_extract_relevant_stats.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+
+setup() {
+  tmpdir="$BATS_TMPDIR/work"
+  mkdir -p "$tmpdir"
+  cd "$tmpdir"
+  cp "$BATS_TEST_DIRNAME/data/example.flagstat.txt" .
+}
+
+@test "extract_relevant_stats parses flagstat" {
+  run bash "$BATS_TEST_DIRNAME/../Modules/02_alignment/extract_relevant_stats"
+  [ "$status" -eq 0 ]
+
+  expected_header=$'sample_name\ttotal_reads\tpercent_mapped\tpercent_properly_paired\tpercent_singletons'
+  [ "${lines[0]}" = "$expected_header" ]
+
+  [ "${lines[1]}" = $'example\t4\t100.00\t100.00\t0.00' ]
+}


### PR DESCRIPTION
## Summary
- add bats-based test for `extract_relevant_stats`
- include small sample flagstat data for testing
- document how to run the test suite

## Testing
- `bats tests`

------
https://chatgpt.com/codex/tasks/task_e_6842d28c3dfc8333ad92d35d1ae174ee